### PR TITLE
Correction image  / ratio / ouverture des citations / trim pseudo

### DIFF
--- a/TopicLivePlus.user.js
+++ b/TopicLivePlus.user.js
@@ -269,10 +269,10 @@ class Message {
         } else {
             this.id_message = parseInt($message.attr('data-id'), 10);
         }
-        this.date = $(TL.class_date, $message).text().replace(/[\r\n]|#[0-9]+$/g, '').trim();
+        this.date = $(TL.class_date, $message).text().replace(/[\r\n]|#[0-9]+$/g, '');
         this.edition = $message.find('.info-edition-msg').text();
         this.$message = $message;
-        this.pseudo = $('.bloc-pseudo-msg', $message).text().replace(/[\r\n]/g, '').trim();
+        this.pseudo = $('.bloc-pseudo-msg', $message).text().replace(/[\r\n]/g, '');
         this.supprime = false;
     }
 
@@ -329,7 +329,7 @@ class Message {
                     txt
                 }) => {
                     const $msg = TL.formu.obtenirMessage();
-                    let nvmsg = `> Le ${this.date} ${this.pseudo} a écrit :\n>`;
+                    let nvmsg = `> Le ${this.date.trim()} ${this.pseudo.trim()} a écrit :\n>`;
                     nvmsg += `${txt.split('\n').join('\n> ')}\n\n`;
                     if ($msg[0].value === '') {
                         Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value").set.call($msg[0], `${nvmsg}\n`);

--- a/TopicLivePlus.user.js
+++ b/TopicLivePlus.user.js
@@ -269,10 +269,10 @@ class Message {
         } else {
             this.id_message = parseInt($message.attr('data-id'), 10);
         }
-        this.date = $(TL.class_date, $message).text().replace(/[\r\n]|#[0-9]+$/g, '');
+        this.date = $(TL.class_date, $message).text().replace(/[\r\n]|#[0-9]+$/g, '').trim();
         this.edition = $message.find('.info-edition-msg').text();
         this.$message = $message;
-        this.pseudo = $('.bloc-pseudo-msg', $message).text().replace(/[\r\n]/g, '');
+        this.pseudo = $('.bloc-pseudo-msg', $message).text().replace(/[\r\n]/g, '').trim();
         this.supprime = false;
     }
 
@@ -350,21 +350,35 @@ class Message {
     /**
      * Permet de déplier les citations imbriquées.
      */
-    fixDeroulerCitation() {
-        this.trouver('blockquote').click(function() {
-            $(this).attr('data-visible', '1');
-        });
-    }
+     fixDeroulerCitation() {
+         this.trouver('.text-enrichi-forum > blockquote.blockquote-jv > blockquote').each(function () {
+             const $quote = $(this);
+             // Ajoute le bouton nested-quote-toggle-box au blocquote
+             const $buttonOpenQuote = $('<div class="nested-quote-toggle-box"></div>');
+             $quote.prepend($buttonOpenQuote);
+             // Attache le listener
+             $buttonOpenQuote.on('click', function () {
+                 const $blockquote = $buttonOpenQuote.closest('.blockquote-jv');
+                 const visible = $blockquote.attr('data-visible');
+                 $blockquote.attr('data-visible', visible === '1' ? '' : '1');
+             });
+         });
+     }
+
+
 
     /**
      * AJOUT : Corrige la source des images pour gérer la transparence et les GIFs.
      */
     fixImages() {
-        this.trouver(TL.class_contenu).find('img').each(function() {
+        this.trouver(TL.class_contenu).find('img.img-shack').each(function () {
             const $img = $(this);
-            const altSrc = $img.attr('alt');
-            if (altSrc && (altSrc.startsWith('http') || altSrc.startsWith('//'))) {
-                $img.attr('src', altSrc);
+            const src = $img.attr('src');
+            const extension = $img.attr('alt').split('.').pop(); // alt pour extension
+            if (src && src.includes('/minis/')) {
+                const direct = src.replace(/\/minis\/(.*)\.\w+$/, `/fichiers/$1.${extension}`);
+                $img.attr('src', direct); 
+                $img.css('object-fit', 'contain');
             }
         });
     }


### PR DESCRIPTION
Beaucoup de corrections dans cette PR  

Premièrement il y a un trim Sur les pseudos et la date c'est une fonction un peu plus moderne de javascript qui permet d'effacer les espaces inutiles autour d'une valeur   

finto les :

```> Le 31 août 2025 à 07:31:12                                xxxxx                                     a écrit :```

Maintenant les espaces sont nettoyés :    

 
```> Le 31 août 2025 à 07:31:12 xxxxx a écrit :```

Sur les nouveaux blocs cités Ça permet de gagner en lisibilité dans le JV code    

--------------------------------------------------------------------------------

J'ai ajouté un argument CSS  :   
$img.css('object-fit', 'contain'); => Il permet de respecter le ratio de l'image d'origine qui n'est pas forcément en 4/3 sinon elle serait déformée   


------------------------------------------------------

J'ai grugé en me servant de ce qui se faisait sur risibank et sur le code du chat :    
Pour remplacer les images par la transparence **tu ne peux pas te contenter de prendre la version alt.**   

En effet même si c'est remplacé en JS dans le code source de la page alt contient l'u RL par défaut si la personne a mis en ligne avec le cadre alt va être une page HTML contenant le cadre pas l'image.   
Exemple ou remplacer avec le alt ne marchera pas :   
https://www.noelshack.com/2018-27-4-1530827992-jesusreup.png => Si quelqu'un a posté le lien avec le cadre il y aura ça mais quand tu vas le mettre en source ça ne marchera pas car c'est une page HTML et pas une image.   



Pour résoudre ça je remplace **/minis/**  par **/fichiers/**  Et ensuite comme quoi on a besoin quand même de alt je viens chercher l'extension. Car l'extension au format miniature est toujours en PNG ce qui n'est pas forcément le cas de la source.


------------------------------------------------------

Dernier point très important c'est enfin l'ouverture ou la fermeture des citations En ajoutant manuellement la balise sur les nouveaux blocs et en ajoutant un événement JS en même temps   

--------------------------------------------   

Donc ça résout :   

les problèmes de ratio d'images,    
les images qui auraient été postées avec le cadre   
Les citations à rallonge au niveau du pseudo   
Le fait de pouvoir ouvrir les citations avec la balise appropriée sur les blocs créés par topic Alive     